### PR TITLE
feat: add netlify function for express backend

### DIFF
--- a/RenovatePro/netlify/functions/api.ts
+++ b/RenovatePro/netlify/functions/api.ts
@@ -1,0 +1,6 @@
+import serverless from "serverless-http";
+import { createApp } from "../../server/app";
+
+const app = await createApp();
+
+export const handler = serverless(app);

--- a/RenovatePro/package.json
+++ b/RenovatePro/package.json
@@ -51,6 +51,7 @@
     "drizzle-zod": "^0.7.0",
     "embla-carousel-react": "^8.6.0",
     "express": "^4.21.2",
+    "serverless-http": "^3.2.0",
     "express-session": "^1.18.1",
     "framer-motion": "^11.13.1",
     "input-otp": "^1.4.2",

--- a/RenovatePro/server/app.ts
+++ b/RenovatePro/server/app.ts
@@ -1,0 +1,48 @@
+import express, { type Request, type Response, type NextFunction } from "express";
+import { registerRoutes } from "./routes";
+import { log } from "./vite";
+
+export async function createApp() {
+  const app = express();
+  app.use(express.json());
+  app.use(express.urlencoded({ extended: false }));
+
+  app.use((req, res, next) => {
+    const start = Date.now();
+    const path = req.path;
+    let capturedJsonResponse: Record<string, any> | undefined = undefined;
+
+    const originalResJson = res.json.bind(res);
+    res.json = function (bodyJson, ...args) {
+      capturedJsonResponse = bodyJson;
+      return originalResJson(bodyJson, ...args);
+    } as typeof res.json;
+
+    res.on("finish", () => {
+      const duration = Date.now() - start;
+      if (path.startsWith("/api")) {
+        let logLine = `${req.method} ${path} ${res.statusCode} in ${duration}ms`;
+        if (capturedJsonResponse) {
+          logLine += ` :: ${JSON.stringify(capturedJsonResponse)}`;
+        }
+        if (logLine.length > 80) {
+          logLine = logLine.slice(0, 79) + "…";
+        }
+        log(logLine);
+      }
+    });
+
+    next();
+  });
+
+  registerRoutes(app);
+
+  app.use((err: any, _req: Request, res: Response, _next: NextFunction) => {
+    const status = err.status || err.statusCode || 500;
+    const message = err.message || "Internal Server Error";
+    res.status(status).json({ message });
+    throw err;
+  });
+
+  return app;
+}

--- a/RenovatePro/server/index.ts
+++ b/RenovatePro/server/index.ts
@@ -1,55 +1,12 @@
-import express, { type Request, Response, NextFunction } from "express";
-import { registerRoutes } from "./routes";
+import { createServer } from "http";
+import { createApp } from "./app";
 import { setupVite, serveStatic, log } from "./vite";
 
-const app = express();
-app.use(express.json());
-app.use(express.urlencoded({ extended: false }));
-
-app.use((req, res, next) => {
-  const start = Date.now();
-  const path = req.path;
-  let capturedJsonResponse: Record<string, any> | undefined = undefined;
-
-  const originalResJson = res.json;
-  res.json = function (bodyJson, ...args) {
-    capturedJsonResponse = bodyJson;
-    return originalResJson.apply(res, [bodyJson, ...args]);
-  };
-
-  res.on("finish", () => {
-    const duration = Date.now() - start;
-    if (path.startsWith("/api")) {
-      let logLine = `${req.method} ${path} ${res.statusCode} in ${duration}ms`;
-      if (capturedJsonResponse) {
-        logLine += ` :: ${JSON.stringify(capturedJsonResponse)}`;
-      }
-
-      if (logLine.length > 80) {
-        logLine = logLine.slice(0, 79) + "…";
-      }
-
-      log(logLine);
-    }
-  });
-
-  next();
-});
-
 (async () => {
-  const server = await registerRoutes(app);
+  const app = await createApp();
+  const server = createServer(app);
 
-  app.use((err: any, _req: Request, res: Response, _next: NextFunction) => {
-    const status = err.status || err.statusCode || 500;
-    const message = err.message || "Internal Server Error";
-
-    res.status(status).json({ message });
-    throw err;
-  });
-
-  // importantly only setup vite in development and after
-  // setting up all the other routes so the catch-all route
-  // doesn't interfere with the other routes
+  // only setup Vite in development after other routes
   if (app.get("env") === "development") {
     await setupVite(app, server);
   } else {

--- a/RenovatePro/server/routes.ts
+++ b/RenovatePro/server/routes.ts
@@ -1,10 +1,9 @@
 import type { Express } from "express";
-import { createServer, type Server } from "http";
 import { storage } from "./storage";
 import { insertContactSchema, insertConsultationSchema, insertCostEstimateSchema } from "@shared/schema";
 import { z } from "zod";
 
-export async function registerRoutes(app: Express): Promise<Server> {
+export function registerRoutes(app: Express) {
   // Contact form submission
   app.post("/api/contacts", async (req, res) => {
     try {
@@ -86,7 +85,6 @@ export async function registerRoutes(app: Express): Promise<Server> {
     }
   });
 
-  // Get all cost estimates
   app.get("/api/cost-estimates", async (req, res) => {
     try {
       const estimates = await storage.getCostEstimates();
@@ -96,6 +94,4 @@ export async function registerRoutes(app: Express): Promise<Server> {
     }
   });
 
-  const httpServer = createServer(app);
-  return httpServer;
 }

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,5 @@
+[build]
+  base = "RenovatePro"
+  command = "npm run build"
+  publish = "dist/public"
+  functions = "netlify/functions"


### PR DESCRIPTION
## Summary
- create `createApp` helper for express setup
- wrap express in Netlify function via serverless-http
- add Netlify config for build and functions

## Testing
- `npm run build`
- `npm run check` *(fails: Type 'string | null | undefined' is not assignable to type 'string | null')*

------
https://chatgpt.com/codex/tasks/task_e_689537021b44832699d3ed0fd0763d04