### PR TITLE
fix: enable ESM output and add TS preset

### DIFF
--- a/RenovatePro/package.json
+++ b/RenovatePro/package.json
@@ -77,6 +77,7 @@
     "zod-validation-error": "^3.4.0"
   },
   "devDependencies": {
+    "@babel/preset-typescript": "^7.24.7",
     "@replit/vite-plugin-cartographer": "^0.2.8",
     "@replit/vite-plugin-runtime-error-modal": "^0.0.3",
     "@tailwindcss/typography": "^0.5.15",

--- a/RenovatePro/vite.config.ts
+++ b/RenovatePro/vite.config.ts
@@ -27,6 +27,11 @@ export default defineConfig({
   build: {
     outDir: path.resolve(import.meta.dirname, "dist/public"),
     emptyOutDir: true,
+    rollupOptions: {
+      output: {
+        format: "esm",
+      },
+    },
   },
   server: {
     fs: {


### PR DESCRIPTION
## Summary
- configure Vite build to emit ESM to support top-level await
- add `@babel/preset-typescript` to dev dependencies

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm run build`
- `npm run check` *(fails: TypeScript errors in server/storage.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68953d6ccc0083268b35390733e8c900