### PR TITLE
fix: enable ESM output and ensure build deps

### DIFF
--- a/RenovatePro/package.json
+++ b/RenovatePro/package.json
@@ -77,6 +77,7 @@
     "zod-validation-error": "^3.4.0"
   },
   "devDependencies": {
+    "@babel/preset-typescript": "^7.24.7",
     "@replit/vite-plugin-cartographer": "^0.2.8",
     "@replit/vite-plugin-runtime-error-modal": "^0.0.3",
     "@tailwindcss/typography": "^0.5.15",
@@ -94,6 +95,7 @@
     "autoprefixer": "^10.4.20",
     "drizzle-kit": "^0.30.4",
     "esbuild": "^0.25.0",
+    "lightningcss": "^1.29.2",
     "postcss": "^8.4.47",
     "tailwindcss": "^3.4.17",
     "tsx": "^4.19.1",

--- a/RenovatePro/vite.config.ts
+++ b/RenovatePro/vite.config.ts
@@ -27,6 +27,12 @@ export default defineConfig({
   build: {
     outDir: path.resolve(import.meta.dirname, "dist/public"),
     emptyOutDir: true,
+    rollupOptions: {
+      output: {
+        format: "esm",
+      },
+      external: ["esbuild"],
+    },
   },
   server: {
     fs: {


### PR DESCRIPTION
## Summary
- configure Vite build to emit ESM and mark `esbuild` as external
- add `@babel/preset-typescript` and `lightningcss` to dev dependencies

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@babel%2fpreset-typescript)*
- `npm run build`
- `npm run check` *(fails: TypeScript errors in server/storage.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68953d6ccc0083268b35390733e8c900