### PR TITLE
fix: remove top-level await from function build

### DIFF
--- a/RenovatePro/netlify/functions/api.ts
+++ b/RenovatePro/netlify/functions/api.ts
@@ -1,6 +1,9 @@
 import serverless from "serverless-http";
 import { createApp } from "../../server/app";
 
-const app = await createApp();
+const handlerPromise = createApp().then((app) => serverless(app));
 
-export const handler = serverless(app);
+export const handler = async (event: any, context: any) => {
+  const handler = await handlerPromise;
+  return handler(event, context);
+};

--- a/RenovatePro/package.json
+++ b/RenovatePro/package.json
@@ -77,6 +77,7 @@
     "zod-validation-error": "^3.4.0"
   },
   "devDependencies": {
+    "@babel/preset-typescript": "^7.24.7",
     "@replit/vite-plugin-cartographer": "^0.2.8",
     "@replit/vite-plugin-runtime-error-modal": "^0.0.3",
     "@tailwindcss/typography": "^0.5.15",
@@ -94,6 +95,7 @@
     "autoprefixer": "^10.4.20",
     "drizzle-kit": "^0.30.4",
     "esbuild": "^0.25.0",
+    "lightningcss": "^1.29.2",
     "postcss": "^8.4.47",
     "tailwindcss": "^3.4.17",
     "tsx": "^4.19.1",

--- a/RenovatePro/server/app.ts
+++ b/RenovatePro/server/app.ts
@@ -1,6 +1,6 @@
 import express, { type Request, type Response, type NextFunction } from "express";
 import { registerRoutes } from "./routes";
-import { log } from "./vite";
+import { log } from "./log";
 
 export async function createApp() {
   const app = express();

--- a/RenovatePro/server/index.ts
+++ b/RenovatePro/server/index.ts
@@ -1,6 +1,7 @@
 import { createServer } from "http";
 import { createApp } from "./app";
-import { setupVite, serveStatic, log } from "./vite";
+import { setupVite, serveStatic } from "./vite";
+import { log } from "./log";
 
 (async () => {
   const app = await createApp();

--- a/RenovatePro/server/log.ts
+++ b/RenovatePro/server/log.ts
@@ -1,0 +1,10 @@
+export function log(message: string, source = "express") {
+  const formattedTime = new Date().toLocaleTimeString("en-US", {
+    hour: "numeric",
+    minute: "2-digit",
+    second: "2-digit",
+    hour12: true,
+  });
+
+  console.log(`${formattedTime} [${source}] ${message}`);
+}

--- a/RenovatePro/server/vite.ts
+++ b/RenovatePro/server/vite.ts
@@ -8,17 +8,6 @@ import { nanoid } from "nanoid";
 
 const viteLogger = createLogger();
 
-export function log(message: string, source = "express") {
-  const formattedTime = new Date().toLocaleTimeString("en-US", {
-    hour: "numeric",
-    minute: "2-digit",
-    second: "2-digit",
-    hour12: true,
-  });
-
-  console.log(`${formattedTime} [${source}] ${message}`);
-}
-
 export async function setupVite(app: Express, server: Server) {
   const serverOptions = {
     middlewareMode: true,
@@ -26,8 +15,15 @@ export async function setupVite(app: Express, server: Server) {
     allowedHosts: true as const,
   };
 
+  const userConfig =
+    typeof viteConfig === "function"
+      ? await (viteConfig as any)({
+          command: "serve",
+          mode: process.env.NODE_ENV || "development",
+        })
+      : viteConfig;
   const vite = await createViteServer({
-    ...viteConfig,
+    ...userConfig,
     configFile: false,
     customLogger: {
       ...viteLogger,

--- a/RenovatePro/vite.config.ts
+++ b/RenovatePro/vite.config.ts
@@ -1,14 +1,16 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 import path from "path";
+import { fileURLToPath } from "url";
 import runtimeErrorOverlay from "@replit/vite-plugin-runtime-error-modal";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 export default defineConfig({
   plugins: [
     react(),
     runtimeErrorOverlay(),
-    ...(process.env.NODE_ENV !== "production" &&
-    process.env.REPL_ID !== undefined
+    ...(process.env.NODE_ENV !== "production" && process.env.REPL_ID !== undefined
       ? [
           await import("@replit/vite-plugin-cartographer").then((m) =>
             m.cartographer(),
@@ -18,15 +20,21 @@ export default defineConfig({
   ],
   resolve: {
     alias: {
-      "@": path.resolve(import.meta.dirname, "client", "src"),
-      "@shared": path.resolve(import.meta.dirname, "shared"),
-      "@assets": path.resolve(import.meta.dirname, "attached_assets"),
+      "@": path.resolve(__dirname, "client", "src"),
+      "@shared": path.resolve(__dirname, "shared"),
+      "@assets": path.resolve(__dirname, "attached_assets"),
     },
   },
-  root: path.resolve(import.meta.dirname, "client"),
+  root: path.resolve(__dirname, "client"),
   build: {
-    outDir: path.resolve(import.meta.dirname, "dist/public"),
+    outDir: path.resolve(__dirname, "dist/public"),
     emptyOutDir: true,
+    rollupOptions: {
+      output: {
+        format: "esm",
+      },
+      external: ["esbuild"],
+    },
   },
   server: {
     fs: {

--- a/netlify.toml
+++ b/netlify.toml
@@ -3,3 +3,7 @@
   command = "npm run build"
   publish = "dist/public"
   functions = "netlify/functions"
+
+[functions]
+  node_bundler = "esbuild"
+  external_node_modules = ["esbuild", "lightningcss"]


### PR DESCRIPTION
## Summary
- resolve Netlify API handler lazily to avoid top-level await
- extract logging utility to decouple server app from Vite-only code
- externalize native modules for Netlify functions and retain ESM build output

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@babel%2fpreset-typescript)*
- `npm run build`
- `npm run check` *(fails: TypeScript errors in server/storage.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68953d6ccc0083268b35390733e8c900