### PR TITLE
Forward contact submissions to n8n webhook

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,4 +19,8 @@ npm run build    # build for production
 npm run check    # type-check with TypeScript
 ```
 
+## Environment Variables
+
+Set `N8N_WEBHOOK_URL` to an n8n webhook endpoint to forward contact form submissions for further processing (emails, Google Sheets, etc.).
+
 See [`RenovatePro/replit.md`](RenovatePro/replit.md) for a more detailed architectural overview.

--- a/RenovatePro/server/routes.ts
+++ b/RenovatePro/server/routes.ts
@@ -9,6 +9,18 @@ export function registerRoutes(app: Express) {
     try {
       const validatedData = insertContactSchema.parse(req.body);
       const contact = await storage.createContact(validatedData);
+
+      const webhookUrl = process.env.N8N_WEBHOOK_URL;
+      if (webhookUrl) {
+        fetch(webhookUrl, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(contact),
+        }).catch((err) => {
+          console.error("Error forwarding contact to n8n:", err);
+        });
+      }
+
       res.json(contact);
     } catch (error) {
       if (error instanceof z.ZodError) {


### PR DESCRIPTION
## Summary
- forward `/api/contacts` submissions to an n8n webhook when `N8N_WEBHOOK_URL` is set
- document `N8N_WEBHOOK_URL` environment variable for contact form automation

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run check` *(fails: Type '{ id: `${string}-${string}-${string}-${string}-${string}`; createdAt: Date; email: string; firstName: string; lastName: string; phone: string; projectType?: string | null | undefined; serviceArea?: string | null | undefined; projectDetails?: string | ... 1 more ... | undefined; preferredContact?: string | ... 1 more...' is not assignable to type '{ id: string; email: string; projectType: string | null; firstName: string; lastName: string; phone: string; serviceArea: string | null; projectDetails: string | null; preferredContact: string | null; createdAt: Date | null; }'.)*

------
https://chatgpt.com/codex/tasks/task_e_689612300fc883268688c5b5c2708895