### PR TITLE
Forward contact submissions to n8n webhook

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,4 +19,8 @@ npm run build    # build for production
 npm run check    # type-check with TypeScript
 ```
 
+## Environment Variables
+
+Set `N8N_WEBHOOK_URL` to an n8n webhook endpoint to forward contact form submissions for further processing (emails, Google Sheets, etc.).
+
 See [`RenovatePro/replit.md`](RenovatePro/replit.md) for a more detailed architectural overview.

--- a/RenovatePro/server/routes.ts
+++ b/RenovatePro/server/routes.ts
@@ -9,6 +9,18 @@ export function registerRoutes(app: Express) {
     try {
       const validatedData = insertContactSchema.parse(req.body);
       const contact = await storage.createContact(validatedData);
+
+      const webhookUrl = process.env.N8N_WEBHOOK_URL;
+      if (webhookUrl) {
+        fetch(webhookUrl, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(contact),
+        }).catch((err) => {
+          console.error("Error forwarding contact to n8n:", err);
+        });
+      }
+
       res.json(contact);
     } catch (error) {
       if (error instanceof z.ZodError) {

--- a/RenovatePro/server/storage.ts
+++ b/RenovatePro/server/storage.ts
@@ -58,10 +58,14 @@ export class MemStorage implements IStorage {
 
   async createContact(insertContact: InsertContact): Promise<Contact> {
     const id = randomUUID();
-    const contact: Contact = { 
-      ...insertContact, 
+    const contact: Contact = {
+      ...insertContact,
       id,
-      createdAt: new Date()
+      createdAt: new Date(),
+      serviceArea: insertContact.serviceArea ?? null,
+      projectType: insertContact.projectType ?? null,
+      projectDetails: insertContact.projectDetails ?? null,
+      preferredContact: insertContact.preferredContact ?? null,
     };
     this.contacts.set(id, contact);
     return contact;
@@ -75,11 +79,15 @@ export class MemStorage implements IStorage {
 
   async createConsultation(insertConsultation: InsertConsultation): Promise<Consultation> {
     const id = randomUUID();
-    const consultation: Consultation = { 
-      ...insertConsultation, 
+    const consultation: Consultation = {
+      ...insertConsultation,
       id,
       status: "pending",
-      createdAt: new Date()
+      createdAt: new Date(),
+      serviceArea: insertConsultation.serviceArea ?? null,
+      projectType: insertConsultation.projectType ?? null,
+      projectDetails: insertConsultation.projectDetails ?? null,
+      preferredDate: insertConsultation.preferredDate ?? null,
     };
     this.consultations.set(id, consultation);
     return consultation;
@@ -103,10 +111,11 @@ export class MemStorage implements IStorage {
 
   async createCostEstimate(insertEstimate: InsertCostEstimate): Promise<CostEstimate> {
     const id = randomUUID();
-    const estimate: CostEstimate = { 
-      ...insertEstimate, 
+    const estimate: CostEstimate = {
+      ...insertEstimate,
       id,
-      createdAt: new Date()
+      createdAt: new Date(),
+      squareFootage: insertEstimate.squareFootage ?? null,
     };
     this.costEstimates.set(id, estimate);
     return estimate;

--- a/netlify.toml
+++ b/netlify.toml
@@ -7,3 +7,8 @@
 [functions]
   node_bundler = "esbuild"
   external_node_modules = ["esbuild", "lightningcss"]
+
+[[redirects]]
+  from = "/api/*"
+  to = "/.netlify/functions/api/:splat"
+  status = 200


### PR DESCRIPTION
## Summary
- forward `/api/contacts` submissions to an n8n webhook when `N8N_WEBHOOK_URL` is set
- redirect `/api/*` requests to the Netlify `api` function to expose Express routes in production
- normalize optional fields in in-memory storage to satisfy TypeScript

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_689612300fc883268688c5b5c2708895