### PR TITLE
Forward contact submissions to n8n webhook

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,4 +19,8 @@ npm run build    # build for production
 npm run check    # type-check with TypeScript
 ```
 
+## Environment Variables
+
+Set `N8N_WEBHOOK_URL` to an n8n webhook endpoint to forward contact form submissions for further processing (emails, Google Sheets, etc.).
+
 See [`RenovatePro/replit.md`](RenovatePro/replit.md) for a more detailed architectural overview.

--- a/RenovatePro/client/src/components/contact/contact-form.tsx
+++ b/RenovatePro/client/src/components/contact/contact-form.tsx
@@ -1,5 +1,5 @@
-import { useState } from "react";
-import { useForm } from "react-hook-form";
+import { useEffect } from "react";
+import { useForm, Controller } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -30,7 +30,7 @@ export default function ContactForm() {
     handleSubmit,
     reset,
     setValue,
-    watch,
+    control,
     formState: { errors }
   } = useForm<ContactFormData>({
     resolver: zodResolver(contactFormSchema),
@@ -38,6 +38,11 @@ export default function ContactForm() {
       preferredContact: "either"
     }
   });
+
+  useEffect(() => {
+    register("serviceArea");
+    register("projectType");
+  }, [register]);
 
   const contactMutation = useMutation({
     mutationFn: async (data: ContactFormData) => {
@@ -209,25 +214,31 @@ export default function ContactForm() {
             <Label className="text-sm font-medium text-warm-gray mb-3">
               Preferred Contact Method
             </Label>
-            <RadioGroup
-              defaultValue="either"
-              onValueChange={(value) => setValue("preferredContact", value as "phone" | "email" | "either")}
-              className="flex gap-6"
-              data-testid="radio-contact-method"
-            >
-              <div className="flex items-center space-x-2">
-                <RadioGroupItem value="phone" id="phone-contact" />
-                <Label htmlFor="phone-contact">Phone Call</Label>
-              </div>
-              <div className="flex items-center space-x-2">
-                <RadioGroupItem value="email" id="email-contact" />
-                <Label htmlFor="email-contact">Email</Label>
-              </div>
-              <div className="flex items-center space-x-2">
-                <RadioGroupItem value="either" id="either-contact" />
-                <Label htmlFor="either-contact">Either</Label>
-              </div>
-            </RadioGroup>
+            <Controller
+              name="preferredContact"
+              control={control}
+              render={({ field }) => (
+                <RadioGroup
+                  onValueChange={field.onChange}
+                  value={field.value}
+                  className="flex gap-6"
+                  data-testid="radio-contact-method"
+                >
+                  <div className="flex items-center space-x-2">
+                    <RadioGroupItem value="phone" id="phone-contact" />
+                    <Label htmlFor="phone-contact">Phone Call</Label>
+                  </div>
+                  <div className="flex items-center space-x-2">
+                    <RadioGroupItem value="email" id="email-contact" />
+                    <Label htmlFor="email-contact">Email</Label>
+                  </div>
+                  <div className="flex items-center space-x-2">
+                    <RadioGroupItem value="either" id="either-contact" />
+                    <Label htmlFor="either-contact">Either</Label>
+                  </div>
+                </RadioGroup>
+              )}
+            />
           </div>
 
           <Button 

--- a/RenovatePro/server/routes.ts
+++ b/RenovatePro/server/routes.ts
@@ -9,6 +9,18 @@ export function registerRoutes(app: Express) {
     try {
       const validatedData = insertContactSchema.parse(req.body);
       const contact = await storage.createContact(validatedData);
+
+      const webhookUrl = process.env.N8N_WEBHOOK_URL;
+      if (webhookUrl) {
+        fetch(webhookUrl, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(contact),
+        }).catch((err) => {
+          console.error("Error forwarding contact to n8n:", err);
+        });
+      }
+
       res.json(contact);
     } catch (error) {
       if (error instanceof z.ZodError) {

--- a/RenovatePro/server/storage.ts
+++ b/RenovatePro/server/storage.ts
@@ -58,10 +58,14 @@ export class MemStorage implements IStorage {
 
   async createContact(insertContact: InsertContact): Promise<Contact> {
     const id = randomUUID();
-    const contact: Contact = { 
-      ...insertContact, 
+    const contact: Contact = {
+      ...insertContact,
       id,
-      createdAt: new Date()
+      createdAt: new Date(),
+      serviceArea: insertContact.serviceArea ?? null,
+      projectType: insertContact.projectType ?? null,
+      projectDetails: insertContact.projectDetails ?? null,
+      preferredContact: insertContact.preferredContact ?? null,
     };
     this.contacts.set(id, contact);
     return contact;
@@ -75,11 +79,15 @@ export class MemStorage implements IStorage {
 
   async createConsultation(insertConsultation: InsertConsultation): Promise<Consultation> {
     const id = randomUUID();
-    const consultation: Consultation = { 
-      ...insertConsultation, 
+    const consultation: Consultation = {
+      ...insertConsultation,
       id,
       status: "pending",
-      createdAt: new Date()
+      createdAt: new Date(),
+      serviceArea: insertConsultation.serviceArea ?? null,
+      projectType: insertConsultation.projectType ?? null,
+      projectDetails: insertConsultation.projectDetails ?? null,
+      preferredDate: insertConsultation.preferredDate ?? null,
     };
     this.consultations.set(id, consultation);
     return consultation;
@@ -103,10 +111,11 @@ export class MemStorage implements IStorage {
 
   async createCostEstimate(insertEstimate: InsertCostEstimate): Promise<CostEstimate> {
     const id = randomUUID();
-    const estimate: CostEstimate = { 
-      ...insertEstimate, 
+    const estimate: CostEstimate = {
+      ...insertEstimate,
       id,
-      createdAt: new Date()
+      createdAt: new Date(),
+      squareFootage: insertEstimate.squareFootage ?? null,
     };
     this.costEstimates.set(id, estimate);
     return estimate;

--- a/netlify.toml
+++ b/netlify.toml
@@ -7,3 +7,8 @@
 [functions]
   node_bundler = "esbuild"
   external_node_modules = ["esbuild", "lightningcss"]
+
+[[redirects]]
+  from = "/api/*"
+  to = "/.netlify/functions/api/:splat"
+  status = 200


### PR DESCRIPTION
## Summary
- forward `/api/contacts` submissions to an n8n webhook when `N8N_WEBHOOK_URL` is set
- redirect `/api/*` requests to the Netlify `api` function to expose Express routes in production
- normalize optional fields in in-memory storage to satisfy TypeScript
- wire preferred contact selection to React Hook Form and register optional selects so submitted data reflects user choice

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_689612300fc883268688c5b5c2708895